### PR TITLE
return unescaped value

### DIFF
--- a/src/resources/views/widgets/relation_panel.blade.php
+++ b/src/resources/views/widgets/relation_panel.blade.php
@@ -56,7 +56,7 @@
                                 <strong>{{$field['label'] ?? ''}}:</strong>
                             </td>
                             <td>
-                                <span>{{$value ?? ''}}</span>
+                                <span>{!!$value ?? ''!!}</span>
                             </td>
                         </tr>
                     @endforeach

--- a/src/resources/views/widgets/relation_table.blade.php
+++ b/src/resources/views/widgets/relation_table.blade.php
@@ -78,7 +78,7 @@
                             }
                         @endphp
                         <td>
-                            <span>{{$value}}</span>
+                            <span>{!!$value!!}</span>
                         </td>
                     @endforeach
                     @if($widget['buttons'] === true)


### PR DESCRIPTION
for customizing return value, like icons, etc.

Example:
![image](https://user-images.githubusercontent.com/35516476/102842427-86c7d580-4439-11eb-926b-cbe8861e73ad.png)
